### PR TITLE
[POC] Colorize backtrace

### DIFF
--- a/lib/debug/backtrace_formatter.rb
+++ b/lib/debug/backtrace_formatter.rb
@@ -2,6 +2,17 @@ module DEBUGGER__
   class BacktraceFormatter
     attr_reader :frames
 
+    COLOR_CODES = {
+      green: 10,
+      yellow: 11,
+      blue: 12,
+      megenta: 13,
+      cyan: 14,
+      orange: 214
+    }
+
+    COLOR_RESET_POSTFIX = "\u001b[0m"
+
     def initialize(frames)
       @frames = frames
     end
@@ -19,9 +30,25 @@ module DEBUGGER__
 
     def formatted_trace(i)
       frame = @frames[i]
-      result = "#{frame.call_identifier_str} at #{frame.location_str}"
-      result += " #=> #{frame.return_value_str}" if frame.return_value_str
+      location_str = colorize(frame.location_str, :green)
+      call_identifier_str = colorize(frame.call_identifier_str, :yellow)
+
+      result = "#{call_identifier_str} at #{location_str}"
+
+      if frame.return_value_str
+        return_value_str = colorize(frame.return_value_str, :megenta)
+        result += " #=> #{return_value_str}"
+      end
+
       result
+    end
+
+    private
+
+    def colorize(content, color)
+      color_code = COLOR_CODES[color]
+      color_prefix = "\u001b[38;5;#{color_code}m"
+      "#{color_prefix}#{content}#{COLOR_RESET_POSTFIX}"
     end
   end
 end


### PR DESCRIPTION
This PR it to demonstrate how easy it'll be to change backtrace's representation with the `BacktraceFormatter` introduced in  https://github.com/ruby/debug/pull/23. It's also mergeable once https://github.com/ruby/debug/pull/23 is merged.

<img width="80%" alt="colorized testing example" src="https://user-images.githubusercontent.com/5079556/119217377-701ecb00-bb0c-11eb-8275-da095f58990a.png">

<img width="80%" alt="colorized wide traces" src="https://user-images.githubusercontent.com/5079556/119217374-6e550780-bb0c-11eb-9d6d-78c7edc6b343.png">
