### PR TITLE
Update color test for IRB struct member name coloring

### DIFF
--- a/test/console/color_test.rb
+++ b/test/console/color_test.rb
@@ -33,7 +33,7 @@ module DEBUGGER__
         end
       end
 
-      { "#{GREEN}#<struct #{CLEAR} foo#{GREEN}=#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{RED}b#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}\n": dummy_class.new('b'),
+      { "#{GREEN}#<struct #{CLEAR} #{CYAN}foo#{CLEAR}#{GREEN}=#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{RED}b#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}#{GREEN}>#{CLEAR}\n": dummy_class.new('b'),
         "#{RED}#{BOLD}\"#{CLEAR}#{RED}hoge#{CLEAR}#{RED}#{BOLD}\"#{CLEAR}\n": 'hoge'}.each do |k, v|
         expected = k.to_s
         obj = v


### PR DESCRIPTION
The latest IRB version wraps struct member names in CYAN, so the
expected output in test_colored_inspect_color_objects_if_use_colorize
needs to wrap `foo` with CYAN/CLEAR escape sequences.